### PR TITLE
Root functions should allow nullable args

### DIFF
--- a/src/Pure.DI.Core/Core/ApiInvocationProcessor.cs
+++ b/src/Pure.DI.Core/Core/ApiInvocationProcessor.cs
@@ -1087,7 +1087,17 @@ sealed class ApiInvocationProcessor(
         if (genericName.TypeArgumentList.Arguments is [{} argTypeSyntax]
             && invocation.ArgumentList.Arguments is [{ Expression: {} nameArgExpression }, ..] args)
         {
-            var argType = semantic.GetTypeSymbol<INamedTypeSymbol>(semanticModel, argTypeSyntax);
+            var argTypeInfo = semanticModel.GetTypeInfo(argTypeSyntax);
+            if ((argTypeInfo.Type ?? argTypeInfo.ConvertedType) is not INamedTypeSymbol argType)
+            {
+                argType = semantic.GetTypeSymbol<INamedTypeSymbol>(semanticModel, argTypeSyntax);
+            }
+
+            if (argTypeSyntax is NullableTypeSyntax && argType.IsReferenceType)
+            {
+                argType = (INamedTypeSymbol)argType.WithNullableAnnotation(NullableAnnotation.Annotated);
+            }
+
             var tags = BuildTags(semanticModel, args.Skip(1));
             var name = GetName(
                 nameArgExpression,

--- a/src/Pure.DI.Core/Core/Code/BuildTools.cs
+++ b/src/Pure.DI.Core/Core/Code/BuildTools.cs
@@ -142,6 +142,13 @@ sealed class BuildTools(
             }
         }
 
+        if (varInjection.Var.InstanceType.IsReferenceType
+            && varInjection.Var.InstanceType.NullableAnnotation == NullableAnnotation.Annotated
+            && varInjection.ContractType.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            variableCode = $"{variableCode}!";
+        }
+
         if (!ctx.RootContext.Graph.Source.Hints.IsOnDependencyInjectionEnabled)
         {
             return variableCode;

--- a/src/Pure.DI.Core/Core/Code/Parts/ParameterizedConstructorBuilder.cs
+++ b/src/Pure.DI.Core/Core/Code/Parts/ParameterizedConstructorBuilder.cs
@@ -40,7 +40,7 @@ sealed class ParameterizedConstructorBuilder(
             foreach (var arg in classArgs)
             {
                 var nullCheck = "";
-                if (arg.InstanceType.IsReferenceType)
+                if (arg.InstanceType.IsReferenceType && arg.InstanceType.NullableAnnotation != NullableAnnotation.Annotated)
                 {
                     nullCheck = $" ?? throw new {Names.SystemNamespace}ArgumentNullException(nameof({arg.Node.Arg?.Source.ArgName}))";
                 }
@@ -55,7 +55,7 @@ sealed class ParameterizedConstructorBuilder(
             foreach (var arg in setupContextArgs)
             {
                 var nullCheck = "";
-                if (arg.Type.IsReferenceType)
+                if (arg.Type.IsReferenceType && arg.Type.NullableAnnotation != NullableAnnotation.Annotated)
                 {
                     nullCheck = $" ?? throw new {Names.SystemNamespace}ArgumentNullException(nameof({arg.Name}))";
                 }

--- a/src/Pure.DI.Core/Core/Code/Parts/RootMethodsBuilder.cs
+++ b/src/Pure.DI.Core/Core/Code/Parts/RootMethodsBuilder.cs
@@ -120,7 +120,7 @@ sealed class RootMethodsBuilder(
             var indentToken = Disposables.Empty;
             if (root.IsMethod)
             {
-                foreach (var arg in root.RootArgs.Where(i => i.InstanceType.IsReferenceType))
+                foreach (var arg in root.RootArgs.Where(i => i.InstanceType.IsReferenceType && i.InstanceType.NullableAnnotation != NullableAnnotation.Annotated))
                 {
                     code.AppendLine($"if ({buildTools.NullCheck(composition.Compilation, arg.Name)}) throw new {Names.SystemNamespace}ArgumentNullException(nameof({arg.Name}));");
                 }

--- a/src/Pure.DI.Core/Core/Code/TypeResolver.cs
+++ b/src/Pure.DI.Core/Core/Code/TypeResolver.cs
@@ -36,7 +36,7 @@ sealed class TypeResolver(
                 }
                 else
                 {
-                    description = new TypeDescription(symbolNames.GetGlobalName(type), ImmutableArray<TypeDescription>.Empty, typeParam);
+                    description = new TypeDescription(GetGlobalName(type), ImmutableArray<TypeDescription>.Empty, typeParam);
                 }
 
                 break;
@@ -55,6 +55,17 @@ sealed class TypeResolver(
             }
                 break;
 
+            case INamedTypeSymbol
+            {
+                ConstructedFrom.SpecialType: Microsoft.CodeAnalysis.SpecialType.System_Nullable_T,
+                TypeArguments: [{} nullableValueType]
+            }:
+            {
+                var nullableValueTypeDescription = Resolve(setup, nullableValueType);
+                description = nullableValueTypeDescription with { Name = $"{nullableValueTypeDescription.Name}?" };
+            }
+                break;
+
             case INamedTypeSymbol namedTypeSymbol:
             {
                 var typeArgs = new List<string>();
@@ -66,7 +77,8 @@ sealed class TypeResolver(
                 }
 
                 var name = string.Join("", namedTypeSymbol.ToDisplayParts().TakeWhile(i => i.ToString() != "<"));
-                description = new TypeDescription($"{name}<{string.Join(", ", typeArgs)}>", args.Distinct().ToList(), typeParam);
+                var nullableSuffix = namedTypeSymbol is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated } ? "?" : "";
+                description = new TypeDescription($"{name}<{string.Join(", ", typeArgs)}>{nullableSuffix}", args.Distinct().ToList(), typeParam);
             }
                 break;
 
@@ -76,10 +88,14 @@ sealed class TypeResolver(
                 break;
 
             default:
-                description = new TypeDescription(symbolNames.GetGlobalName(type), ImmutableArray<TypeDescription>.Empty, typeParam);
+                description = new TypeDescription(GetGlobalName(type), ImmutableArray<TypeDescription>.Empty, typeParam);
                 break;
         }
 
         return description;
     }
+
+    private string GetGlobalName(ITypeSymbol type) => type is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated }
+        ? $"{symbolNames.GetGlobalName(type)}?"
+        : symbolNames.GetGlobalName(type);
 }

--- a/tests/Pure.DI.UsageTests/Basics/RootArgumentsScenarioNullable.cs
+++ b/tests/Pure.DI.UsageTests/Basics/RootArgumentsScenarioNullable.cs
@@ -1,0 +1,111 @@
+/*
+$v=true
+$p=5
+$d=Root arguments
+$h=Use root arguments when you need to pass state into a specific root. Define them with `RootArg<T>(string argName)` (optionally with tags) and use them like any other dependency. A root that uses at least one root argument becomes a method, and only arguments used in that root's object graph appear in the method signature. Use unique argument names to avoid collisions.
+$h=Root arguments are useful when runtime values belong to one entry point, not to the whole composition.
+$h=>[!NOTE]
+$h=>Actually, root arguments work like normal bindings. The difference is that they bind to the values of the arguments. These values will be injected wherever they are required.
+$h=
+$f=When using root arguments, compilation warnings are emitted if `Resolve` methods are generated because these methods cannot create such roots. Disable `Resolve` via `Hint(Hint.Resolve, "Off")`, or ignore the warnings and accept the risks.
+$r=Shouldly
+$f=Limitations: roots with root arguments become methods and are incompatible with generated `Resolve` methods.
+$f=Common pitfalls:
+$f=- Reusing ambiguous argument names for different concepts.
+$f=- Forgetting to disable or avoid `Resolve` usage in these setups.
+$f=See also: [Composition arguments](composition-arguments.md), [Resolve hint](resolve-hint.md).
+*/
+
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable ArrangeTypeModifiers
+
+namespace Pure.DI.UsageTests.Basics.RootArgumentsScenarioNullable;
+
+using Shouldly;
+using Xunit;
+using static Tag;
+
+// {
+//# using Pure.DI;
+//# using static Pure.DI.Tag;
+// }
+
+public class ScenarioNullable
+{
+    [Fact]
+    public void Run()
+    {
+        // Root arguments make Resolve unusable, so disable Resolve generation
+        // Resolve = Off
+// {
+        DI.Setup(nameof(Composition))
+            // Disable Resolve methods because root arguments are not compatible
+            .Hint(Hint.Resolve, "Off")
+            .Bind<IDatabaseServiceNullable>().To<DatabaseServiceNullable>()
+            .Bind<IApplicationNullable>().To<ApplicationNullable>()
+
+            // Root arguments serve as values passed
+            // to the composition root method
+            .RootArg<int?>("port")
+            .RootArg<string?>("connectionString")
+
+            // An argument can be tagged
+            // to be injectable by type and this tag
+            .RootArg<string>("appName", AppDetail)
+
+            // Composition root
+            .Root<IApplicationNullable>("CreateApplication");
+
+        var composition = new Composition();
+        
+        string? connectionString = null;
+        int? port = 8080;
+
+        // Creates an application with specific arguments
+        var app = composition.CreateApplication(
+            appName: "MySuperApp",
+            port: port,
+            connectionString: connectionString);
+
+        app.Name.ShouldBe("MySuperApp");
+        app.Database.Port.ShouldBe(8080);
+        app.Database.ConnectionString.ShouldBeNull();
+// }
+        composition.SaveClassDiagram();
+    }
+}
+
+// {
+interface IDatabaseServiceNullable
+{
+    int? Port { get; }
+
+    string? ConnectionString { get; }
+}
+
+class DatabaseServiceNullable(int? port, string? connectionString) : IDatabaseServiceNullable
+{
+    public int? Port { get; } = port;
+
+    public string? ConnectionString { get; } = connectionString;
+}
+
+interface IApplicationNullable
+{
+    string Name { get; }
+
+    IDatabaseServiceNullable Database { get; }
+}
+
+class ApplicationNullable(
+    [Tag(AppDetail)] string name,
+    IDatabaseServiceNullable database)
+    : IApplicationNullable
+{
+    public string Name { get; } = name;
+
+    public IDatabaseServiceNullable Database { get; } = database;
+}
+// }


### PR DESCRIPTION
when doing `.RootArg` I noticed nullable values weren't being respected/propagated.   This PR should allow that.