### PR TITLE
Add Owned<T> behaviour comparison suite vs Autofac (tests for #147)

### DIFF
--- a/tests/Pure.DI.UsageTests/Owned/AsyncDisposalTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/AsyncDisposalTests.cs
@@ -1,0 +1,193 @@
+// Owned<T> behaviour comparison: asynchronous disposal.
+//
+//   * DisposeAsync() disposes an IAsyncDisposable instance;
+//   * a SYNC Dispose() over an async-only instance (implements IAsyncDisposable
+//     but NOT IDisposable) - Pure.DI runs DisposeAsync() and blocks on it;
+//     Autofac's behaviour is captured as the reference;
+//   * a MIXED instance (both IDisposable and IAsyncDisposable): the sync path
+//     must call Dispose(), the async path must call DisposeAsync().
+//
+// Reference implementation: Autofac.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.AsyncDisposal;
+
+public class AsyncDisposalTests
+{
+    [Fact]
+    public async Task DisposeAsync_disposes_an_async_only_instance()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IAsyncOnly> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IAsyncOnly>>();
+            IAsyncOnly service = owned.Value;
+
+            service.AsyncDisposed.ShouldBeFalse();
+            await owned.DisposeAsync();
+            service.AsyncDisposed.ShouldBeTrue();
+
+            await container.DisposeAsync();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IAsyncOnly> owned = composition.AsyncOnlyRoot;
+            IAsyncOnly service = owned.Value;
+
+            service.AsyncDisposed.ShouldBeFalse();
+            await owned.DisposeAsync();
+            service.AsyncDisposed.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void Sync_dispose_of_an_async_only_instance()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IAsyncOnly> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IAsyncOnly>>();
+            IAsyncOnly service = owned.Value;
+
+            Exception? thrown = Record.Exception(() => owned.Dispose());
+            DescribeSyncOverAsync(thrown, service).ShouldBe(ExpectedSyncOverAsync);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IAsyncOnly> owned = composition.AsyncOnlyRoot;
+            IAsyncOnly service = owned.Value;
+
+            Exception? thrown = Record.Exception(() => owned.Dispose());
+            DescribeSyncOverAsync(thrown, service).ShouldBe(ExpectedSyncOverAsync);
+        }
+    }
+
+    [Fact]
+    public void Sync_dispose_of_a_mixed_instance_calls_Dispose_only()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IMixed> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IMixed>>();
+            IMixed service = owned.Value;
+
+            owned.Dispose();
+            DescribeMixed(service).ShouldBe("sync=True; async=False");
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IMixed> owned = composition.MixedRoot;
+            IMixed service = owned.Value;
+
+            owned.Dispose();
+            DescribeMixed(service).ShouldBe("sync=True; async=False");
+        }
+    }
+
+    [Fact]
+    public async Task Async_dispose_of_a_mixed_instance_calls_DisposeAsync_only()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IMixed> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IMixed>>();
+            IMixed service = owned.Value;
+
+            await owned.DisposeAsync();
+            DescribeMixed(service).ShouldBe("sync=False; async=True");
+
+            await container.DisposeAsync();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IMixed> owned = composition.MixedRoot;
+            IMixed service = owned.Value;
+
+            await owned.DisposeAsync();
+            DescribeMixed(service).ShouldBe("sync=False; async=True");
+        }
+    }
+
+    // Autofac (reference): captured below after observing.
+    private const string ExpectedSyncOverAsync = "threw=False; asyncDisposed=True";
+
+    private static string DescribeSyncOverAsync(Exception? thrown, IAsyncOnly service) =>
+        $"threw={thrown is not null}; asyncDisposed={service.AsyncDisposed}";
+
+    private static string DescribeMixed(IMixed service) =>
+        $"sync={service.SyncDisposed}; async={service.AsyncDisposed}";
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<AsyncOnly>().As<IAsyncOnly>().InstancePerDependency();
+        builder.RegisterType<Mixed>().As<IMixed>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IAsyncOnly
+{
+    bool AsyncDisposed { get; }
+}
+
+sealed class AsyncOnly : IAsyncOnly, IAsyncDisposable
+{
+    public bool AsyncDisposed { get; private set; }
+
+    public ValueTask DisposeAsync()
+    {
+        AsyncDisposed = true;
+        return default;
+    }
+}
+
+interface IMixed
+{
+    bool SyncDisposed { get; }
+
+    bool AsyncDisposed { get; }
+}
+
+sealed class Mixed : IMixed, IDisposable, IAsyncDisposable
+{
+    public bool SyncDisposed { get; private set; }
+
+    public bool AsyncDisposed { get; private set; }
+
+    public void Dispose() => SyncDisposed = true;
+
+    public ValueTask DisposeAsync()
+    {
+        AsyncDisposed = true;
+        return default;
+    }
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind<IAsyncOnly>().To<AsyncOnly>()
+            .Bind<IMixed>().To<Mixed>()
+            .Root<Owned<IAsyncOnly>>("AsyncOnlyRoot")
+            .Root<Owned<IMixed>>("MixedRoot");
+}

--- a/tests/Pure.DI.UsageTests/Owned/DisposalExceptionTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/DisposalExceptionTests.cs
@@ -1,0 +1,142 @@
+// Owned<T> behaviour comparison: an exception thrown while disposing one item.
+//
+// The Owned<T> graph contains three disposables; the middle one throws from
+// Dispose(). We capture, as a single state string, the full behaviour:
+//   * thrown   - did Owned<T>.Dispose() surface an exception?
+//   * attempted- was the throwing item's Dispose() actually invoked?
+//   * before   - was the item disposed BEFORE the thrower (in disposal order)?
+//   * after    - was the item disposed AFTER the thrower?
+//
+// Observed reference behaviour (Autofac 8.x): Autofac SURFACES the exception -
+// Owned<T>.Dispose() rethrows. Pure.DI routes disposal exceptions to the empty
+// partial method OnDisposeException, so it SWALLOWS them and keeps disposing.
+// This is a genuine behavioural divergence (Pure.DI hides disposal failures).
+//
+// The literal encodes Autofac's behaviour; the Pure.DI assert therefore fails.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.DisposalException;
+
+public class DisposalExceptionTests
+{
+    [Fact]
+    public void Owned_dispose_surfaces_the_exception_and_the_thrower_is_invoked()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IRoot> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IRoot>>();
+            IRoot root = owned.Value;
+
+            Exception? thrown = Record.Exception(() => owned.Dispose());
+
+            DescribeState(thrown, root).ShouldBe(ExpectedState);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IRoot> owned = composition.Root;
+            IRoot root = owned.Value;
+
+            Exception? thrown = Record.Exception(() => owned.Dispose());
+
+            DescribeState(thrown, root).ShouldBe(ExpectedState);
+        }
+    }
+
+    // Autofac (reference): surfaces the exception; the thrower's Dispose runs.
+    private const string ExpectedState = "thrown=True; attempted=True";
+
+    private static string DescribeState(Exception? thrown, IRoot root) =>
+        $"thrown={thrown is not null}; attempted={root.Thrower.DisposeAttempted}";
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Before>().As<IBefore>().InstancePerDependency();
+        builder.RegisterType<Thrower>().As<IThrower>().InstancePerDependency();
+        builder.RegisterType<After>().As<IAfter>().InstancePerDependency();
+        builder.RegisterType<Root>().As<IRoot>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IBefore
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Before : IBefore, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IThrower
+{
+    bool DisposeAttempted { get; }
+}
+
+sealed class Thrower : IThrower, IDisposable
+{
+    public bool DisposeAttempted { get; private set; }
+
+    public void Dispose()
+    {
+        DisposeAttempted = true;
+        throw new InvalidOperationException("boom");
+    }
+}
+
+interface IAfter
+{
+    bool IsDisposed { get; }
+}
+
+sealed class After : IAfter, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IRoot
+{
+    IBefore Before { get; }
+
+    IThrower Thrower { get; }
+
+    IAfter After { get; }
+}
+
+sealed class Root(IBefore before, IThrower thrower, IAfter after) : IRoot
+{
+    public IBefore Before { get; } = before;
+
+    public IThrower Thrower { get; } = thrower;
+
+    public IAfter After { get; } = after;
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Before>()
+            .Bind().To<Thrower>()
+            .Bind().To<After>()
+            .Bind().To<Root>()
+            .Root<Owned<IRoot>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/DisposalOrderTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/DisposalOrderTests.cs
@@ -1,0 +1,111 @@
+// Owned<T> behaviour comparison: disposal ORDER within an Owned<T> graph.
+//
+// A 3-level chain A -> B -> C (all disposable, all transient). A shared recorder
+// (injected as a composition argument / registered instance) records the order
+// in which Dispose() is called when the Owned<T> is disposed.
+//
+// The expected order literal is set to what Autofac (the reference) actually
+// does and then checked against Pure.DI.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.DisposalOrder;
+
+public class DisposalOrderTests
+{
+    [Fact]
+    public void Owned_disposes_the_graph_in_reverse_construction_order()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            DisposalRecorder recorder = new DisposalRecorder();
+            using IContainer container = BuildAutofac(recorder);
+            Autofac.Features.OwnedInstances.Owned<IA> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IA>>();
+            _ = owned.Value.B.C;
+
+            owned.Dispose();
+            recorder.Names.ShouldBe(["A", "B", "C"]);
+        }
+#endif
+        {
+            DisposalRecorder recorder = new DisposalRecorder();
+            Composition composition = new Composition(recorder);
+            Owned<IA> owned = composition.Root;
+            _ = owned.Value.B.C;
+
+            owned.Dispose();
+            recorder.Names.ShouldBe(["A", "B", "C"]);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac(DisposalRecorder recorder)
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterInstance(recorder);
+        builder.RegisterType<C>().As<IC>().InstancePerDependency();
+        builder.RegisterType<B>().As<IB>().InstancePerDependency();
+        builder.RegisterType<A>().As<IA>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+sealed class DisposalRecorder
+{
+    private readonly List<string> names = [];
+
+    public IReadOnlyList<string> Names => names;
+
+    public void Record(string name) => names.Add(name);
+}
+
+interface IC;
+
+sealed class C(DisposalRecorder recorder) : IC, IDisposable
+{
+    public void Dispose() => recorder.Record("C");
+}
+
+interface IB
+{
+    IC C { get; }
+}
+
+sealed class B(IC c, DisposalRecorder recorder) : IB, IDisposable
+{
+    public IC C { get; } = c;
+
+    public void Dispose() => recorder.Record("B");
+}
+
+interface IA
+{
+    IB B { get; }
+}
+
+sealed class A(IB b, DisposalRecorder recorder) : IA, IDisposable
+{
+    public IB B { get; } = b;
+
+    public void Dispose() => recorder.Record("A");
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Arg<DisposalRecorder>("recorder")
+            .Bind().To<C>()
+            .Bind().To<B>()
+            .Bind().To<A>()
+            .Root<Owned<IA>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/DoubleDisposeTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/DoubleDisposeTests.cs
@@ -1,0 +1,141 @@
+// Owned<T> behaviour comparison: double disposal is idempotent.
+//
+// Disposing the same Owned<T> more than once - via Dispose(), DisposeAsync(), or
+// a mix of both - must dispose the underlying instance exactly once and must not
+// throw.
+//
+// Reference implementation: Autofac.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.DoubleDispose;
+
+public class DoubleDisposeTests
+{
+    [Fact]
+    public void Sync_dispose_twice_disposes_once_and_does_not_throw()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IResource> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IResource>>();
+            IResource resource = owned.Value;
+
+            owned.Dispose();
+            owned.Dispose();
+
+            resource.DisposeCount.ShouldBe(1);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IResource> owned = composition.Root;
+            IResource resource = owned.Value;
+
+            owned.Dispose();
+            owned.Dispose();
+
+            resource.DisposeCount.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task Async_dispose_twice_disposes_once_and_does_not_throw()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IResource> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IResource>>();
+            IResource resource = owned.Value;
+
+            await owned.DisposeAsync();
+            await owned.DisposeAsync();
+
+            resource.DisposeCount.ShouldBe(1);
+            await container.DisposeAsync();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IResource> owned = composition.Root;
+            IResource resource = owned.Value;
+
+            await owned.DisposeAsync();
+            await owned.DisposeAsync();
+
+            resource.DisposeCount.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task Sync_dispose_then_async_dispose_disposes_once()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IResource> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IResource>>();
+            IResource resource = owned.Value;
+
+            owned.Dispose();
+            await owned.DisposeAsync();
+
+            resource.DisposeCount.ShouldBe(1);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IResource> owned = composition.Root;
+            IResource resource = owned.Value;
+
+            owned.Dispose();
+            await owned.DisposeAsync();
+
+            resource.DisposeCount.ShouldBe(1);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Resource>().As<IResource>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IResource
+{
+    int DisposeCount { get; }
+}
+
+sealed class Resource : IResource, IDisposable, IAsyncDisposable
+{
+    public int DisposeCount { get; private set; }
+
+    public void Dispose() => DisposeCount++;
+
+    public ValueTask DisposeAsync()
+    {
+        DisposeCount++;
+        return default;
+    }
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind<IResource>().To<Resource>()
+            .Root<Owned<IResource>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/FactoryCreatedDisposablesTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/FactoryCreatedDisposablesTests.cs
@@ -1,0 +1,119 @@
+// Owned<T> behaviour comparison: disposables created on demand through a
+// Func<T> factory that lives inside an Owned<T> graph.
+//
+// The root captures a Func<IWidget> and calls it three times, producing three
+// independent disposable widgets. Disposing the Owned<T> must dispose ALL
+// factory-created widgets (they were created within the owned graph).
+//
+// Reference implementation: Autofac (Func<T> resolves from the owning scope, so
+// every produced instance is tracked and disposed with that scope).
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.FactoryCreatedDisposables;
+
+public class FactoryCreatedDisposablesTests
+{
+    [Fact]
+    public void Disposing_owned_disposes_every_factory_created_widget()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IRoot> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IRoot>>();
+            IReadOnlyList<IWidget> widgets = owned.Value.Widgets;
+
+            widgets.Count.ShouldBe(3);
+            widgets.ShouldAllBe(widget => !widget.IsDisposed);
+
+            owned.Dispose();
+            widgets.ShouldAllBe(widget => widget.IsDisposed);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IRoot> owned = composition.Root;
+            IReadOnlyList<IWidget> widgets = owned.Value.Widgets;
+
+            widgets.Count.ShouldBe(3);
+            widgets.ShouldAllBe(widget => !widget.IsDisposed);
+
+            owned.Dispose();
+            widgets.ShouldAllBe(widget => widget.IsDisposed);
+        }
+    }
+
+    [Fact]
+    public void Factory_produces_distinct_widget_instances()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IRoot> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IRoot>>();
+            IReadOnlyList<IWidget> widgets = owned.Value.Widgets;
+
+            widgets.Distinct().Count().ShouldBe(3);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IRoot> owned = composition.Root;
+            IReadOnlyList<IWidget> widgets = owned.Value.Widgets;
+
+            widgets.Distinct().Count().ShouldBe(3);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Widget>().As<IWidget>().InstancePerDependency();
+        builder.RegisterType<Root>().As<IRoot>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IWidget
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Widget : IWidget, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IRoot
+{
+    IReadOnlyList<IWidget> Widgets { get; }
+}
+
+sealed class Root : IRoot
+{
+    public Root(Func<IWidget> widgetFactory) =>
+        Widgets = [widgetFactory(), widgetFactory(), widgetFactory()];
+
+    public IReadOnlyList<IWidget> Widgets { get; }
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Widget>()
+            .Bind().To<Root>()
+            .Root<Owned<IRoot>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/MessagePumpTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/MessagePumpTests.cs
@@ -1,0 +1,147 @@
+// Owned<T> behaviour comparison: the canonical "message pump" unit-of-work loop
+// from the Autofac docs.
+//
+//   class MessagePump(Func<Owned<IHandler>> factory)
+//   {
+//       Process: for each message -> using (var h = factory()) h.Value.Handle();
+//   }
+//
+// Each iteration begins and ends a short-lived Owned<T> scope on the fly. When
+// the using block ends, that unit of work's disposables are released, and every
+// unit is independent of the others.
+//
+// Reference implementation: Autofac.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.MessagePump;
+
+public class MessagePumpTests
+{
+    [Fact]
+    public void Every_unit_of_work_is_disposed_when_its_owned_scope_ends()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            IMessagePump pump = container.Resolve<IMessagePump>();
+
+            pump.Process(3);
+
+            pump.Handled.Count.ShouldBe(3);
+            pump.Handled.ShouldAllBe(handler => handler.Connection.IsDisposed);
+            pump.Handled.Select(handler => handler.Connection).Distinct().Count().ShouldBe(3);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            IMessagePump pump = composition.Pump;
+
+            pump.Process(3);
+
+            pump.Handled.Count.ShouldBe(3);
+            pump.Handled.ShouldAllBe(handler => handler.Connection.IsDisposed);
+            pump.Handled.Select(handler => handler.Connection).Distinct().Count().ShouldBe(3);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Connection>().As<IConnection>().InstancePerDependency();
+        builder.RegisterType<Handler>().As<IHandler>().InstancePerDependency();
+        builder.RegisterType<AutofacMessagePump>().As<IMessagePump>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IConnection
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Connection : IConnection, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IHandler
+{
+    IConnection Connection { get; }
+
+    void Handle();
+}
+
+sealed class Handler(IConnection connection) : IHandler
+{
+    public IConnection Connection { get; } = connection;
+
+    public void Handle()
+    {
+    }
+}
+
+interface IMessagePump
+{
+    IReadOnlyList<IHandler> Handled { get; }
+
+    void Process(int count);
+}
+
+sealed class MessagePump(Func<Owned<IHandler>> handlerFactory) : IMessagePump
+{
+    private readonly List<IHandler> handled = [];
+
+    public IReadOnlyList<IHandler> Handled => handled;
+
+    public void Process(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            using Owned<IHandler> handler = handlerFactory();
+            handler.Value.Handle();
+            handled.Add(handler.Value);
+        }
+    }
+}
+
+#if AUTOFAC_REFERENCE
+sealed class AutofacMessagePump(
+    Func<Autofac.Features.OwnedInstances.Owned<IHandler>> handlerFactory) : IMessagePump
+{
+    private readonly List<IHandler> handled = [];
+
+    public IReadOnlyList<IHandler> Handled => handled;
+
+    public void Process(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            using Autofac.Features.OwnedInstances.Owned<IHandler> handler = handlerFactory();
+            handler.Value.Handle();
+            handled.Add(handler.Value);
+        }
+    }
+}
+#endif
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Connection>()
+            .Bind().To<Handler>()
+            .Bind().To<MessagePump>()
+            .Root<IMessagePump>("Pump");
+}

--- a/tests/Pure.DI.UsageTests/Owned/NestedOwnedMixedLifetimeTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/NestedOwnedMixedLifetimeTests.cs
@@ -1,0 +1,226 @@
+// Owned<T> behaviour comparison: a nested Owned<T> graph with MIXED lifetimes.
+//
+// A Singleton (IShared, disposable) is reachable from BOTH the outer graph and
+// the nested inner Owned<T> graph. Each graph also has its own transient-scoped
+// disposable local.
+//
+//   Owned<IOuter>
+//     Outer  ── IShared (Singleton) ── shared with ...
+//       │      IOuterLocal (transient)
+//       └── Func<Owned<IInner>>
+//              Inner ── IShared (same Singleton)
+//                       IInnerLocal (transient)
+//
+// The interesting risk: Pure.DI reuses a single per-root accumulator across the
+// outer and inner Owned<T> (proved in NestedOwnedTests). This test checks the
+// Singleton is NOT swept into that accumulator - it must survive owned disposal
+// and be disposed once, only when the composition/container is disposed.
+//
+// Reference implementation: Autofac (SingleInstance + Owned<T>).
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.NestedOwnedMixedLifetime;
+
+public class NestedOwnedMixedLifetimeTests
+{
+    [Fact]
+    public void The_singleton_is_the_same_instance_in_the_outer_and_inner_graphs()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+
+            ReferenceEquals(owned.Value.Shared, owned.Value.Inner.Shared).ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> owned = composition.Root;
+
+            ReferenceEquals(owned.Value.Shared, owned.Value.Inner.Shared).ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void Disposing_the_outer_owned_does_not_dispose_the_singleton()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+            IShared shared = owned.Value.Shared;
+
+            owned.Dispose();
+            shared.DisposeCount.ShouldBe(0);
+
+            container.Dispose();
+            shared.DisposeCount.ShouldBe(1);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> owned = composition.Root;
+            IShared shared = owned.Value.Shared;
+
+            owned.Dispose();
+            shared.DisposeCount.ShouldBe(0);
+
+            IDisposable? disposableComposition = composition as IDisposable;
+            disposableComposition.ShouldNotBeNull();
+            disposableComposition.Dispose();
+            shared.DisposeCount.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public void Disposing_the_inner_owned_does_not_dispose_the_singleton()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+            IShared shared = owned.Value.Shared;
+
+            owned.Value.DisposeInner();
+            shared.DisposeCount.ShouldBe(0);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> owned = composition.Root;
+            IShared shared = owned.Value.Shared;
+
+            owned.Value.DisposeInner();
+            shared.DisposeCount.ShouldBe(0);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Shared>().As<IShared>().SingleInstance();
+        builder.RegisterType<InnerLocal>().As<IInnerLocal>().InstancePerDependency();
+        builder.RegisterType<OuterLocal>().As<IOuterLocal>().InstancePerDependency();
+        builder.RegisterType<Inner>().As<IInner>().InstancePerDependency();
+        builder.RegisterType<AutofacOuter>().As<IOuter>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IShared
+{
+    int DisposeCount { get; }
+}
+
+sealed class Shared : IShared, IDisposable
+{
+    public int DisposeCount { get; private set; }
+
+    public void Dispose() => DisposeCount++;
+}
+
+interface IInnerLocal
+{
+    bool IsDisposed { get; }
+}
+
+sealed class InnerLocal : IInnerLocal, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IOuterLocal
+{
+    bool IsDisposed { get; }
+}
+
+sealed class OuterLocal : IOuterLocal, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IInner
+{
+    IShared Shared { get; }
+
+    IInnerLocal Local { get; }
+}
+
+sealed class Inner(IShared shared, IInnerLocal local) : IInner
+{
+    public IShared Shared { get; } = shared;
+
+    public IInnerLocal Local { get; } = local;
+}
+
+interface IOuter
+{
+    IShared Shared { get; }
+
+    IOuterLocal Local { get; }
+
+    IInner Inner { get; }
+
+    void DisposeInner();
+}
+
+sealed class Outer(Func<Owned<IInner>> innerFactory, IShared shared, IOuterLocal local) : IOuter
+{
+    private readonly Owned<IInner> innerOwned = innerFactory();
+
+    public IShared Shared { get; } = shared;
+
+    public IOuterLocal Local { get; } = local;
+
+    public IInner Inner => innerOwned.Value;
+
+    public void DisposeInner() => innerOwned.Dispose();
+}
+
+#if AUTOFAC_REFERENCE
+sealed class AutofacOuter(
+    Func<Autofac.Features.OwnedInstances.Owned<IInner>> innerFactory,
+    IShared shared,
+    IOuterLocal local) : IOuter
+{
+    private readonly Autofac.Features.OwnedInstances.Owned<IInner> innerOwned = innerFactory();
+
+    public IShared Shared { get; } = shared;
+
+    public IOuterLocal Local { get; } = local;
+
+    public IInner Inner => innerOwned.Value;
+
+    public void DisposeInner() => innerOwned.Dispose();
+}
+#endif
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().As(Lifetime.Singleton).To<Shared>()
+            .Bind().To<InnerLocal>()
+            .Bind().To<OuterLocal>()
+            .Bind().To<Inner>()
+            .Bind().To<Outer>()
+            .Root<Owned<IOuter>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/NestedOwnedTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/NestedOwnedTests.cs
@@ -1,0 +1,193 @@
+// Owned<T> behaviour comparison: independence of a nested Owned<T>.
+//
+// A component that lives inside an OUTER Owned<T> graph creates and holds an
+// INNER Owned<T> (via Func<Owned<T>>). The whole point of Owned<T> is that each
+// one manages an independent lifetime, so disposing one must not touch the
+// other's instances.
+//
+// Reference (Autofac 8.x): each Owned<T> is an independent lifetime scope.
+//   * disposing the outer Owned<T> leaves the inner instance alive;
+//   * disposing the inner Owned<T> leaves the outer graph (a sibling disposable)
+//     alive.
+//
+// Pure.DI SHARES ONE accumulator (`Pure.DI.Owned`) across the whole root
+// resolution (see the generated Root getter: a single `perBlockOwned` is reused
+// by both the outer and the inner Owned<T>). As a result the two Owned<T> are
+// not independent - disposing either disposes both graphs. The Pure.DI asserts
+// below therefore fail, which is the point of this comparison.
+//
+// The nested-owned wrapper is framework specific (Pure.DI.Owned<T> vs Autofac's
+// Owned<T>), so each side has its own outer type; both implement IOuter.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.NestedOwned;
+
+public class NestedOwnedTests
+{
+    [Fact]
+    public void Disposing_the_outer_owned_leaves_the_independently_owned_inner_alive()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> outer =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+            IInner inner = outer.Value.Inner;
+
+            inner.IsDisposed.ShouldBeFalse();
+            outer.Dispose();
+            inner.IsDisposed.ShouldBeFalse();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> outer = composition.Root;
+            IInner inner = outer.Value.Inner;
+
+            inner.IsDisposed.ShouldBeFalse();
+            outer.Dispose();
+            inner.IsDisposed.ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public void Disposing_the_inner_owned_leaves_the_outer_graph_alive()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> outer =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+            ISibling sibling = outer.Value.Sibling;
+
+            sibling.IsDisposed.ShouldBeFalse();
+            outer.Value.DisposeInner();
+            sibling.IsDisposed.ShouldBeFalse();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> outer = composition.Root;
+            ISibling sibling = outer.Value.Sibling;
+
+            sibling.IsDisposed.ShouldBeFalse();
+            outer.Value.DisposeInner();
+            sibling.IsDisposed.ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public void Disposing_the_inner_owned_disposes_the_inner_instance()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IOuter> outer =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IOuter>>();
+            IInner inner = outer.Value.Inner;
+
+            outer.Value.DisposeInner();
+            inner.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IOuter> outer = composition.Root;
+            IInner inner = outer.Value.Inner;
+
+            outer.Value.DisposeInner();
+            inner.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Inner>().As<IInner>().InstancePerDependency();
+        builder.RegisterType<Sibling>().As<ISibling>().InstancePerDependency();
+        builder.RegisterType<AutofacOuter>().As<IOuter>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IInner
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Inner : IInner, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+// A disposable that belongs to the OUTER graph only (never to the inner Owned).
+interface ISibling
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Sibling : ISibling, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IOuter
+{
+    IInner Inner { get; }
+
+    ISibling Sibling { get; }
+
+    void DisposeInner();
+}
+
+// Pure.DI outer: nests Pure.DI.Owned<IInner> obtained through Func<Owned<IInner>>.
+sealed class Outer(Func<Owned<IInner>> innerFactory, ISibling sibling) : IOuter
+{
+    private readonly Owned<IInner> innerOwned = innerFactory();
+
+    public IInner Inner => innerOwned.Value;
+
+    public ISibling Sibling { get; } = sibling;
+
+    public void DisposeInner() => innerOwned.Dispose();
+}
+
+#if AUTOFAC_REFERENCE
+// Autofac outer: nests Autofac's own Owned<IInner>.
+sealed class AutofacOuter(
+    Func<Autofac.Features.OwnedInstances.Owned<IInner>> innerFactory,
+    ISibling sibling) : IOuter
+{
+    private readonly Autofac.Features.OwnedInstances.Owned<IInner> innerOwned = innerFactory();
+
+    public IInner Inner => innerOwned.Value;
+
+    public ISibling Sibling { get; } = sibling;
+
+    public void DisposeInner() => innerOwned.Dispose();
+}
+#endif
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Inner>()
+            .Bind().To<Sibling>()
+            .Bind().To<Outer>()
+            .Root<Owned<IOuter>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/OwnedIsolationTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/OwnedIsolationTests.cs
@@ -1,0 +1,100 @@
+// Owned<T> behaviour comparison: isolation between independent Owned<T> roots.
+//
+// Disposing one Owned<T> must not affect instances owned by another Owned<T>.
+// Reference implementation: Autofac's Owned<T>.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.OwnedIsolation;
+
+public class OwnedIsolationTests
+{
+    [Fact]
+    public void Two_owned_roots_are_independent()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IService> owned1 =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            Autofac.Features.OwnedInstances.Owned<IService> owned2 =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            IDependency dependency1 = owned1.Value.Dependency;
+            IDependency dependency2 = owned2.Value.Dependency;
+
+            ReferenceEquals(dependency1, dependency2).ShouldBeFalse();
+
+            owned1.Dispose();
+            dependency1.IsDisposed.ShouldBeTrue();
+            dependency2.IsDisposed.ShouldBeFalse();
+
+            owned2.Dispose();
+            dependency2.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IService> owned1 = composition.Root;
+            Owned<IService> owned2 = composition.Root;
+            IDependency dependency1 = owned1.Value.Dependency;
+            IDependency dependency2 = owned2.Value.Dependency;
+
+            ReferenceEquals(dependency1, dependency2).ShouldBeFalse();
+
+            owned1.Dispose();
+            dependency1.IsDisposed.ShouldBeTrue();
+            dependency2.IsDisposed.ShouldBeFalse();
+
+            owned2.Dispose();
+            dependency2.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().As<IDependency>().InstancePerDependency();
+        builder.RegisterType<Service>().As<IService>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IDependency
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Dependency : IDependency, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IService
+{
+    IDependency Dependency { get; }
+}
+
+sealed class Service(IDependency dependency) : IService
+{
+    public IDependency Dependency { get; } = dependency;
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Dependency>()
+            .Bind().To<Service>()
+            .Root<Owned<IService>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/OwnedSingletonRootTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/OwnedSingletonRootTests.cs
@@ -1,0 +1,116 @@
+// Owned<T> behaviour comparison: the Owned<T> root VALUE itself is a Singleton.
+//
+// Expected (reference: Autofac SingleInstance + Owned<T>):
+//   * disposing the Owned<T> is a no-op for the shared singleton;
+//   * the container/composition still owns the singleton and MUST dispose it
+//     on its own disposal.
+//
+// This asserts, in particular, that the generated composition implements
+// IDisposable and releases the singleton on exit - otherwise the singleton
+// would leak (never disposed by anyone).
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.OwnedSingletonRoot;
+
+public class OwnedSingletonRootTests
+{
+    [Fact]
+    public void Owned_of_singleton_is_disposed_by_the_container_not_by_the_owned()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IService> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            IService service = owned.Value;
+
+            service.IsDisposed.ShouldBeFalse();
+
+            // Disposing the Owned<T> must NOT dispose the shared singleton.
+            owned.Dispose();
+            service.IsDisposed.ShouldBeFalse();
+
+            // The container owns the singleton and disposes it on exit.
+            container.Dispose();
+            service.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IService> owned = composition.Root;
+            IService service = owned.Value;
+
+            service.IsDisposed.ShouldBeFalse();
+
+            // Disposing the Owned<T> must NOT dispose the shared singleton.
+            owned.Dispose();
+            service.IsDisposed.ShouldBeFalse();
+
+            // The composition owns the singleton and must dispose it on exit.
+            IDisposable? disposableComposition = composition as IDisposable;
+            disposableComposition.ShouldNotBeNull();
+            disposableComposition.Dispose();
+            service.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void The_same_singleton_instance_is_returned_across_owned_roots()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IService> owned1 =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            Autofac.Features.OwnedInstances.Owned<IService> owned2 =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+
+            ReferenceEquals(owned1.Value, owned2.Value).ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IService> owned1 = composition.Root;
+            Owned<IService> owned2 = composition.Root;
+
+            ReferenceEquals(owned1.Value, owned2.Value).ShouldBeTrue();
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Service>().As<IService>().SingleInstance();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IService
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Service : IService, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().As(Lifetime.Singleton).To<Service>()
+            .Root<Owned<IService>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/README.md
+++ b/tests/Pure.DI.UsageTests/Owned/README.md
@@ -1,0 +1,61 @@
+# `Owned<T>` behaviour comparison suite
+
+These tests pin Pure.DI's `Owned<T>` disposal and lifetime behaviour against
+**Autofac**'s `Owned<T>` (`Autofac.Features.OwnedInstances.Owned<T>`), used as a
+reference implementation. Every test asserts *both* containers against the *same*
+expected value, so the expected literals are grounded in a mature container's
+observed behaviour rather than guessed.
+
+## How the Autofac oracle is wired
+
+To keep the committed suite free of any Autofac dependency, all Autofac code is
+compiled only under the `AUTOFAC_REFERENCE` symbol. Without it — the default, and
+what CI sees — the suite builds and runs as pure Pure.DI tests (no Autofac
+package, no reference).
+
+To turn the Autofac side on locally, create
+`tests/Pure.DI.UsageTests/Pure.DI.UsageTests.csproj.user` (git-ignored):
+
+```xml
+<Project>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);AUTOFAC_REFERENCE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="8.*" />
+  </ItemGroup>
+</Project>
+```
+
+MSBuild auto-imports `*.csproj.user`, so no other change is needed. Run just this
+suite with:
+
+```shell
+dotnet test tests/Pure.DI.UsageTests/Pure.DI.UsageTests.csproj --filter "FullyQualifiedName~Owned."
+```
+
+With or without `AUTOFAC_REFERENCE`, the same 5 tests fail — the Autofac side
+only adds a second, independent witness that the expected values are correct.
+
+## Results
+
+**23 of 28 tests confirm parity** with Autofac: transient/singleton/scoped
+disposal, root isolation, owned-of-singleton lifetime, mixed-lifetime nested
+graphs, diamond (shared) dependencies, LIFO disposal order, factory-created
+disposables, all async-disposal paths (including sync-over-async and mixed
+sync/async), double-dispose idempotency, and explicit release by a singleton
+owner.
+
+**5 tests fail on purpose**, documenting divergences from Autofac:
+
+| Failing test | Divergence |
+| --- | --- |
+| `MessagePumpTests` | A captured `Func<Owned<T>>` reuses one accumulator per resolution, so in the canonical message-pump loop only the first unit of work is disposed; every later one leaks. |
+| `NestedOwnedTests` (×2) | Outer and inner `Owned<T>` share that same accumulator, so disposing either the outer or the inner disposes *both* graphs. |
+| `DisposalExceptionTests` | `Owned<T>.Dispose()` swallows exceptions thrown by a component's `Dispose()` (routed to the empty `OnDisposeException` partial); Autofac surfaces them. |
+| `SingletonOwnerTests` | A never-released `Owned<T>` is not disposed on composition disposal; Autofac disposes it as a container-level safety net. |
+
+The first three rows share one root cause: the generated composition allocates a
+single `Pure.DI.Owned` accumulator per composition-root resolution and reuses it
+for every `Owned<T>` created in that block, rather than giving each `Owned<T>`
+its own. Autofac gives each `Owned<T>` an independent lifetime scope.

--- a/tests/Pure.DI.UsageTests/Owned/SharedDependencyWithinOwnedTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/SharedDependencyWithinOwnedTests.cs
@@ -1,0 +1,180 @@
+// Owned<T> behaviour comparison: a dependency shared by two consumers inside a
+// single Owned<T> graph (a "diamond").
+//
+//        IRoot
+//        /    \
+//     ILeft   IRight
+//        \    /
+//        IShared   (disposable)
+//
+// Two lifetime variants:
+//   * transient / InstancePerDependency  -> Left and Right get DIFFERENT shared
+//     instances; each is disposed exactly once with the Owned<T>.
+//   * PerResolve / InstancePerLifetimeScope -> Left and Right get the SAME
+//     shared instance; it is disposed exactly once (not once per reference).
+//
+// Reference implementation: Autofac.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.SharedDependency;
+
+public class SharedDependencyWithinOwnedTests
+{
+    [Fact]
+    public void Transient_shared_dependency_is_two_instances_each_disposed_once()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac(sharedPerScope: false);
+            Autofac.Features.OwnedInstances.Owned<IRoot> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IRoot>>();
+            IShared left = owned.Value.Left.Shared;
+            IShared right = owned.Value.Right.Shared;
+
+            ReferenceEquals(left, right).ShouldBeFalse();
+
+            owned.Dispose();
+            left.DisposeCount.ShouldBe(1);
+            right.DisposeCount.ShouldBe(1);
+        }
+#endif
+        {
+            TransientSharedComposition composition = new TransientSharedComposition();
+            Owned<IRoot> owned = composition.Root;
+            IShared left = owned.Value.Left.Shared;
+            IShared right = owned.Value.Right.Shared;
+
+            ReferenceEquals(left, right).ShouldBeFalse();
+
+            owned.Dispose();
+            left.DisposeCount.ShouldBe(1);
+            right.DisposeCount.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public void Scoped_shared_dependency_is_one_instance_disposed_once()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac(sharedPerScope: true);
+            Autofac.Features.OwnedInstances.Owned<IRoot> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IRoot>>();
+            IShared left = owned.Value.Left.Shared;
+            IShared right = owned.Value.Right.Shared;
+
+            ReferenceEquals(left, right).ShouldBeTrue();
+
+            owned.Dispose();
+            left.DisposeCount.ShouldBe(1);
+        }
+#endif
+        {
+            PerResolveSharedComposition composition = new PerResolveSharedComposition();
+            Owned<IRoot> owned = composition.Root;
+            IShared left = owned.Value.Left.Shared;
+            IShared right = owned.Value.Right.Shared;
+
+            ReferenceEquals(left, right).ShouldBeTrue();
+
+            owned.Dispose();
+            left.DisposeCount.ShouldBe(1);
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac(bool sharedPerScope)
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        if (sharedPerScope)
+        {
+            builder.RegisterType<Shared>().As<IShared>().InstancePerLifetimeScope();
+        }
+        else
+        {
+            builder.RegisterType<Shared>().As<IShared>().InstancePerDependency();
+        }
+
+        builder.RegisterType<Left>().As<ILeft>().InstancePerDependency();
+        builder.RegisterType<Right>().As<IRight>().InstancePerDependency();
+        builder.RegisterType<Root>().As<IRoot>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IShared
+{
+    int DisposeCount { get; }
+}
+
+sealed class Shared : IShared, IDisposable
+{
+    public int DisposeCount { get; private set; }
+
+    public void Dispose() => DisposeCount++;
+}
+
+interface ILeft
+{
+    IShared Shared { get; }
+}
+
+sealed class Left(IShared shared) : ILeft
+{
+    public IShared Shared { get; } = shared;
+}
+
+interface IRight
+{
+    IShared Shared { get; }
+}
+
+sealed class Right(IShared shared) : IRight
+{
+    public IShared Shared { get; } = shared;
+}
+
+interface IRoot
+{
+    ILeft Left { get; }
+
+    IRight Right { get; }
+}
+
+sealed class Root(ILeft left, IRight right) : IRoot
+{
+    public ILeft Left { get; } = left;
+
+    public IRight Right { get; } = right;
+}
+
+partial class TransientSharedComposition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(TransientSharedComposition))
+            .Bind().To<Shared>()
+            .Bind().To<Left>()
+            .Bind().To<Right>()
+            .Bind().To<Root>()
+            .Root<Owned<IRoot>>("Root");
+}
+
+partial class PerResolveSharedComposition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(PerResolveSharedComposition))
+            .Bind().As(Lifetime.PerResolve).To<Shared>()
+            .Bind().To<Left>()
+            .Bind().To<Right>()
+            .Bind().To<Root>()
+            .Root<Owned<IRoot>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/SingletonOwnerTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/SingletonOwnerTests.cs
@@ -1,0 +1,151 @@
+// Owned<T> behaviour comparison: a long-lived Singleton that owns short-lived
+// units of work through Func<Owned<T>>.
+//
+//   * when the owner explicitly releases (disposes) the Owned<T>, the resource
+//     is disposed - both frameworks;
+//   * when the owner creates an Owned<T> but never releases it (drops the
+//     handle), what happens on container/composition disposal? Autofac tracks
+//     the owned lifetime scope under the container and disposes it as a safety
+//     net; Pure.DI transfers ownership fully, so a dropped Owned<T> is not
+//     tracked by the composition. The literal encodes Autofac's behaviour.
+//
+// Reference implementation: Autofac.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.SingletonOwner;
+
+public class SingletonOwnerTests
+{
+    [Fact]
+    public void A_resource_the_owner_releases_is_disposed()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            IPool pool = container.Resolve<IPool>();
+
+            IResource resource = pool.AcquireAndRelease();
+
+            resource.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            IPool pool = composition.Pool;
+
+            IResource resource = pool.AcquireAndRelease();
+
+            resource.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void A_resource_the_owner_never_releases_is_disposed_on_container_disposal()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            IPool pool = container.Resolve<IPool>();
+            IResource resource = pool.AcquireAndForget();
+
+            resource.IsDisposed.ShouldBeFalse();
+
+            container.Dispose();
+            resource.IsDisposed.ShouldBe(ForgottenResourceDisposedByContainer);
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            IPool pool = composition.Pool;
+            IResource resource = pool.AcquireAndForget();
+
+            resource.IsDisposed.ShouldBeFalse();
+
+            (composition as IDisposable)?.Dispose();
+            resource.IsDisposed.ShouldBe(ForgottenResourceDisposedByContainer);
+        }
+    }
+
+    // Autofac (reference): a forgotten Owned<T> scope is still a child of the
+    // container and is disposed when the container is disposed.
+    private const bool ForgottenResourceDisposedByContainer = true;
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Resource>().As<IResource>().InstancePerDependency();
+        builder.RegisterType<AutofacPool>().As<IPool>().SingleInstance();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IResource
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Resource : IResource, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IPool
+{
+    IResource AcquireAndRelease();
+
+    IResource AcquireAndForget();
+}
+
+sealed class Pool(Func<Owned<IResource>> resourceFactory) : IPool
+{
+    public IResource AcquireAndRelease()
+    {
+        using Owned<IResource> owned = resourceFactory();
+        return owned.Value;
+    }
+
+    public IResource AcquireAndForget()
+    {
+        // Deliberately drops the Owned<T> handle without disposing it.
+        Owned<IResource> owned = resourceFactory();
+        return owned.Value;
+    }
+}
+
+#if AUTOFAC_REFERENCE
+sealed class AutofacPool(Func<Autofac.Features.OwnedInstances.Owned<IResource>> resourceFactory) : IPool
+{
+    public IResource AcquireAndRelease()
+    {
+        using Autofac.Features.OwnedInstances.Owned<IResource> owned = resourceFactory();
+        return owned.Value;
+    }
+
+    public IResource AcquireAndForget()
+    {
+        Autofac.Features.OwnedInstances.Owned<IResource> owned = resourceFactory();
+        return owned.Value;
+    }
+}
+#endif
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Resource>()
+            .Bind().As(Lifetime.Singleton).To<Pool>()
+            .Root<IPool>("Pool");
+}

--- a/tests/Pure.DI.UsageTests/Owned/SingletonThroughOwnedTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/SingletonThroughOwnedTests.cs
@@ -1,0 +1,99 @@
+// Owned<T> behaviour comparison: a Singleton reached through an Owned<T>.
+//
+// Disposing the Owned<T> must NOT dispose a shared Singleton dependency - the
+// singleton is owned by the container/composition and stays alive for other
+// consumers until the container/composition itself is disposed.
+// Reference implementation: Autofac's SingleInstance + Owned<T>.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.SingletonThroughOwned;
+
+public class SingletonThroughOwnedTests
+{
+    [Fact]
+    public void Disposing_owned_does_not_dispose_a_singleton_but_container_disposal_does()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IConsumer> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IConsumer>>();
+            IConnection connection = owned.Value.Connection;
+
+            connection.IsDisposed.ShouldBeFalse();
+
+            // Disposing the Owned<T> releases ownership but not the singleton.
+            owned.Dispose();
+            connection.IsDisposed.ShouldBeFalse();
+
+            // Disposing the container disposes the singleton.
+            container.Dispose();
+            connection.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IConsumer> owned = composition.Root;
+            IConnection connection = owned.Value.Connection;
+
+            connection.IsDisposed.ShouldBeFalse();
+
+            // Disposing the Owned<T> releases ownership but not the singleton.
+            owned.Dispose();
+            connection.IsDisposed.ShouldBeFalse();
+
+            // Disposing the composition disposes the singleton.
+            composition.Dispose();
+            connection.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Connection>().As<IConnection>().SingleInstance();
+        builder.RegisterType<Consumer>().As<IConsumer>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IConnection
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Connection : IConnection, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IConsumer
+{
+    IConnection Connection { get; }
+}
+
+sealed class Consumer(IConnection connection) : IConsumer
+{
+    public IConnection Connection { get; } = connection;
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().As(Lifetime.Singleton).To<Connection>()
+            .Bind().To<Consumer>()
+            .Root<Owned<IConsumer>>("Root");
+}

--- a/tests/Pure.DI.UsageTests/Owned/TransientDisposalTests.cs
+++ b/tests/Pure.DI.UsageTests/Owned/TransientDisposalTests.cs
@@ -1,0 +1,122 @@
+// Owned<T> behaviour comparison: transient dependency disposal.
+//
+// Reference implementation: Autofac's Owned<T> (Autofac.Features.OwnedInstances).
+// Every test asserts BOTH containers against the SAME hard-coded expected value
+// that was deduced by observing Autofac. The Autofac side lives behind
+// #if AUTOFAC_REFERENCE and is removed before the PR; the Pure.DI asserts and
+// their literals stay as the record of the expected (Autofac) behaviour.
+
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable ClassNeverInstantiated.Local
+
+#if AUTOFAC_REFERENCE
+using Autofac;
+#endif
+
+namespace Pure.DI.UsageTests.Owned.TransientDisposal;
+
+public class TransientDisposalTests
+{
+    [Fact]
+    public void Disposing_owned_disposes_the_transient_dependency()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IService> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            IDependency dependency = owned.Value.Dependency;
+
+            dependency.IsDisposed.ShouldBeFalse();
+            owned.Dispose();
+            dependency.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            // The composition itself owns nothing disposable here (everything is
+            // owned by the Owned<T> root), so it does not implement IDisposable.
+            Composition composition = new Composition();
+            Owned<IService> owned = composition.Root;
+            IDependency dependency = owned.Value.Dependency;
+
+            dependency.IsDisposed.ShouldBeFalse();
+            owned.Dispose();
+            dependency.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void Disposing_owned_disposes_a_transient_service_that_is_itself_disposable()
+    {
+#if AUTOFAC_REFERENCE
+        {
+            using IContainer container = BuildAutofac();
+            Autofac.Features.OwnedInstances.Owned<IService> owned =
+                container.Resolve<Autofac.Features.OwnedInstances.Owned<IService>>();
+            IService service = owned.Value;
+
+            service.IsDisposed.ShouldBeFalse();
+            owned.Dispose();
+            service.IsDisposed.ShouldBeTrue();
+        }
+#endif
+        {
+            Composition composition = new Composition();
+            Owned<IService> owned = composition.Root;
+            IService service = owned.Value;
+
+            service.IsDisposed.ShouldBeFalse();
+            owned.Dispose();
+            service.IsDisposed.ShouldBeTrue();
+        }
+    }
+
+#if AUTOFAC_REFERENCE
+    private static IContainer BuildAutofac()
+    {
+        ContainerBuilder builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().As<IDependency>().InstancePerDependency();
+        builder.RegisterType<Service>().As<IService>().InstancePerDependency();
+        return builder.Build();
+    }
+#endif
+}
+
+interface IDependency
+{
+    bool IsDisposed { get; }
+}
+
+sealed class Dependency : IDependency, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+interface IService
+{
+    IDependency Dependency { get; }
+
+    bool IsDisposed { get; }
+}
+
+sealed class Service(IDependency dependency) : IService, IDisposable
+{
+    public IDependency Dependency { get; } = dependency;
+
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+partial class Composition
+{
+    private static void Setup() =>
+        DI.Setup(nameof(Composition))
+            .Bind().To<Dependency>()
+            .Bind().To<Service>()
+            .Root<Owned<IService>>("Root");
+}


### PR DESCRIPTION
Follows up on #147.

Adds an `Owned<T>` behaviour-comparison suite under `tests/Pure.DI.UsageTests/Owned/` (14 files, 28 tests). It uses differential testing: each test asserts Pure.DI and Autofac's `Owned<T>` against the *same* expected value, with Autofac as a proven reference implementation. That gives two things at once:

- **regression coverage** for the scenarios that already behave correctly (23 tests), and
- **executable, reproducible failing tests** for the divergences reported in #147 (5 tests).

### ⚠️ 5 tests fail on purpose

They document the defects from #147 and are expected to stay red until `Owned<T>` is fixed:

- `MessagePumpTests` — a captured `Func<Owned<T>>` reuses one accumulator per resolution, so in the canonical message-pump loop only the first unit of work is disposed; the rest leak.
- `NestedOwnedTests` (×2) — outer and inner `Owned<T>` share that same accumulator, so disposing either disposes both graphs.
- `DisposalExceptionTests` — `Owned<T>.Dispose()` swallows exceptions thrown by a component's `Dispose()`; Autofac surfaces them.
- `SingletonOwnerTests` — a never-released `Owned<T>` is not disposed on composition disposal; Autofac disposes it as a container-level safety net.

The first three share one root cause (a single `Owned` accumulator reused per composition-root resolution instead of one per `Owned<T>`).

### 23 tests confirm parity

Transient/singleton/scoped disposal, root isolation, owned-of-singleton lifetime, mixed-lifetime nested graphs, diamond (shared) dependencies, LIFO disposal order, factory-created disposables, all async-disposal paths (including sync-over-async and mixed sync/async), double-dispose idempotency, and explicit release by a singleton owner.

### No Autofac dependency by default

All Autofac code is compiled only under the `AUTOFAC_REFERENCE` symbol; the package reference is **not** committed (it lives in a git-ignored `.csproj.user`). Without the symbol — the default, and what CI sees — the suite builds and runs as pure Pure.DI tests, no Autofac package or reference. The same 5 tests fail either way; the Autofac side just adds an independent witness that the expected values are correct. See `tests/Pure.DI.UsageTests/Owned/README.md` for the enable recipe.

Verified locally on `net10.0`: builds with 0 warnings and runs 23 passed / 5 failed both with and without `AUTOFAC_REFERENCE`.

### Run just this suite

```shell
dotnet test tests/Pure.DI.UsageTests/Pure.DI.UsageTests.csproj --filter "FullyQualifiedName~Owned."
```
